### PR TITLE
#749 docker: Added watch to compose override for backend_data_retriev

### DIFF
--- a/src/backend_api/.dockerignore
+++ b/src/backend_api/.dockerignore
@@ -6,3 +6,6 @@ app.egg-info
 .coverage
 htmlcov
 .venv
+
+# Logs
+*.log

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -66,8 +66,8 @@ services:
           action: sync
           target: /app
           ignore:
-            - ./backend_api/.venv
             - .venv
+            - uv.lock
         - path: ./backend_api/pyproject.toml
           action: rebuild
 
@@ -95,6 +95,16 @@ services:
       args:
         INSTALL_DEV: ${INSTALL_DEV-true}
     command: /data_retrieval_app/prestart.sh
+    develop:
+      watch:
+        - path: ./backend_data_retrieval
+          action: sync+restart
+          target: /data_retrieval_app
+          ignore:
+            - .venv/
+            - uv.lock
+        - path: ./backend_data_retrieval/pyproject.toml
+          action: rebuild
 
   frontend:
     restart: "no"


### PR DESCRIPTION
Pay attention to the "+restart" in watch config. This means on every change, the container should restart while developing.